### PR TITLE
Remove quote feature

### DIFF
--- a/mockiato-codegen/src/lib.rs
+++ b/mockiato-codegen/src/lib.rs
@@ -1,7 +1,6 @@
 //! Codegen for `mockiato`. Do not use this crate directly.
 
 #![feature(
-    quote,
     proc_macro_diagnostic,
     proc_macro_span,
     proc_macro_hygiene,


### PR DESCRIPTION
Apparently this feature doesn't exist anymore. I couldn't find any info about it other than a compiler error on the current nightly.